### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
-# Ignite Hydrogen
+**PLEASE NOTE** We are evaluating the changes to Ignite v6 and the removal of Boilerplate Templates
 
+# Ignite Hydrogen
 > This project is still in early development. We do encourage participation and feel free to open Github Issues.
 
 Extending from fantastic and hotest React Native boilerplate [Ignite Red's Bower](https://github.com/infinitered/ignit-bower), the Ignite Hydrogen project is aimed at easily implementing principles and concepts from DelveFore to a specific purpose (more to come soon!).

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-**PLEASE NOTE** We are evaluating the changes to Ignite v6 and the removal of Boilerplate Templates
+**PLEASE NOTE** We are evaluating the changes to Ignite v6 and the removal of Plugins and Third-party support for Boilerplate Templates. To read more on the their decision please see [Jamon Holmgren's post](https://shift.infinite.red/introducing-ignite-4-0-flame-1dfc891f9966)
 
 # Ignite Hydrogen
 > This project is still in early development. We do encourage participation and feel free to open Github Issues.


### PR DESCRIPTION
Ignite Red v6 has removed support for Plugins and Third-party Boilerplates. As such we need to take a new approach and our first step is placing this notice.